### PR TITLE
Set default value of trait

### DIFF
--- a/jupyterlab_{{cookiecutter.project_slug}}/jupyterlab_{{cookiecutter.project_slug}}/labapp.py
+++ b/jupyterlab_{{cookiecutter.project_slug}}/jupyterlab_{{cookiecutter.project_slug}}/labapp.py
@@ -5,7 +5,7 @@ from jupyterlab import labapp
 
 def main():
     os.environ['JUPYTERLAB_DIR'] = os.path.join(sys.prefix, 'share', 'jupyter', '{{ cookiecutter.project_slug }}')
-    labapp.LabApp.app_dir = os.environ['JUPYTERLAB_DIR']
+    labapp.LabApp.app_dir.default_value = os.environ['JUPYTERLAB_DIR']
     labapp.main()
     
     

--- a/jupyterlab_{{cookiecutter.project_slug}}/jupyterlab_{{cookiecutter.project_slug}}/labextensionapp.py
+++ b/jupyterlab_{{cookiecutter.project_slug}}/jupyterlab_{{cookiecutter.project_slug}}/labextensionapp.py
@@ -5,7 +5,7 @@ from jupyterlab import labextensions
 
 def main():
     os.environ['JUPYTERLAB_DIR'] = os.path.join(sys.prefix, 'share', 'jupyter', '{{ cookiecutter.project_slug }}')
-    labextensions.BaseExtensionApp.app_dir = os.environ['JUPYTERLAB_DIR']
+    labextensions.BaseExtensionApp.app_dir.default_value = os.environ['JUPYTERLAB_DIR']
     labextensions.main()
     
 if __name__ == '__main__':


### PR DESCRIPTION
The current code overrides a trait by a fixed value. Therefore, it breaks some CLI usage like requesting the help.

This fixes it by setting the default_value keeping the class attributes as trait.